### PR TITLE
Reuseable embedded resource texture load function

### DIFF
--- a/LevelEditorNativeRendering/LvEdRenderingEngine/Renderer/TextureLib.h
+++ b/LevelEditorNativeRendering/LvEdRenderingEngine/Renderer/TextureLib.h
@@ -24,6 +24,8 @@ public:
     Texture* GetByName(const wchar_t* name);
     static Texture* CreateSolidTexture2D(ID3D11Device* device, int w, int h, uint32_t color);
 
+	static Texture* LoadEmbeddedTexture(ID3D11Device* device, const wchar_t* name);
+
 private:
     
     TextureLib();


### PR DESCRIPTION
Moved the embedded texture load logic currently used for loading the embedded lightbulb PNG into a reusable function, to make using more embedded images easier.