### PR TITLE
Load MEF type catalogs from DLLs in \MEFPlugin

### DIFF
--- a/LevelEditor/LevelEditorApplication.cs
+++ b/LevelEditor/LevelEditorApplication.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Windows.Forms;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Linq;
 
 using Sce.Atf;
 using Sce.Atf.Adaptation;
@@ -179,6 +180,17 @@ namespace LevelEditor
                 catalogs.Add(new AssemblyCatalog(stmPlgAssem));
             }
 
+            // load all dlls in \MEFPlugin
+            string mefpluginDir = pluginDir + "\\MEFPlugin";
+            if (Directory.Exists(mefpluginDir))
+            {
+                var filepaths = Directory.GetFiles(mefpluginDir).Where(path => path.EndsWith(".dll"));
+                foreach (var filepath in filepaths)
+                {
+                    Assembly filepathAssembly = Assembly.LoadFrom(filepath);
+                    catalogs.Add(new AssemblyCatalog(filepathAssembly));
+                }
+            }
             
             AggregateCatalog catalog = new AggregateCatalog(catalogs);
                


### PR DESCRIPTION
We have some shared controls between our ATF apps that we'd like to use in the LevelEditor without modifying too much upstream code. To that end it'd be really nice if we could load MEF type catalogs from DLLs in a subdirectory :)