### PR TITLE
billboardshader: colorize, don't just multiply image intensity

### DIFF
--- a/LevelEditorNativeRendering/LvEdRenderingEngine/Renderer/BillboardShader.cpp
+++ b/LevelEditorNativeRendering/LvEdRenderingEngine/Renderer/BillboardShader.cpp
@@ -138,7 +138,7 @@ void BillboardShader::Draw(const RenderableNode& r)
 
     Matrix::Transpose(r.WorldXform,m_cbPerDraw.Data.worldXform);
     Matrix::Transpose(r.TextureXForm, m_cbPerDraw.Data.textureXForm);
-    m_cbPerDraw.Data.intensity = r.diffuse.x;
+    m_cbPerDraw.Data.color = r.diffuse;
     m_cbPerDraw.Update(dc);
     
     ID3D11ShaderResourceView* diffuseMap[1] = {NULL};    

--- a/LevelEditorNativeRendering/LvEdRenderingEngine/Renderer/BillboardShader.h
+++ b/LevelEditorNativeRendering/LvEdRenderingEngine/Renderer/BillboardShader.h
@@ -47,8 +47,7 @@ private:
     {
         Matrix worldXform;
         Matrix textureXForm;
-        float intensity;
-        float3 pad;
+        float4 color;
     };
 
     ID3D11VertexShader*     m_vertexShader;

--- a/LevelEditorNativeRendering/LvEdRenderingEngine/Shaders/Billboard.hlsl
+++ b/LevelEditorNativeRendering/LvEdRenderingEngine/Shaders/Billboard.hlsl
@@ -13,7 +13,7 @@ cbuffer ConstantBufferPerDraw : register( b1 )
 {
     float4x4   world;
     float4x4   textureTrans;
-    float      intensity;  // 0 to 1
+    float4     color;
 };
 
 
@@ -71,6 +71,6 @@ float4 PSMain( PS_INPUT input ) : SV_TARGET
 {
    float4 fc = diffuseTex.Sample( diffuseSampler, input.tex0 );
    clip(fc.a - 0.5);
-   fc.xyz = fc.xyz * intensity;
+   fc.xyz = fc.xyz * color.xyz;
    return fc;
 }


### PR DESCRIPTION
It's sometimes useful to be able to colorize billboards. This doesn't impact existing usage - the billboard image for lights is unaffected, and it's not like there's more data flying around seeing as the structure was padded with a float3 prior to this.