### PR TITLE
IGameObject.GetGame

### DIFF
--- a/LevelEditor/DomNodeAdapters/GameObject.cs
+++ b/LevelEditor/DomNodeAdapters/GameObject.cs
@@ -1,10 +1,12 @@
 //Copyright © 2014 Sony Computer Entertainment America LLC. See License.txt.
 
+using System.Linq;
 
 using LevelEditorCore;
 
 using Sce.Atf;
 using Sce.Atf.Applications;
+using Sce.Atf.Adaptation;
 using Sce.Atf.Dom;
 using Sce.Atf.VectorMath;
 
@@ -159,6 +161,24 @@ namespace LevelEditor.DomNodeAdapters
         }
       
         #endregion          
+
+        #region IGameObject Members
+        /// <summary>
+        /// Gets the game that owns this game object.</summary>
+        /// <returns>The game that owns this game object, or null if this object isn't owned.</returns>
+        IGame IGameObject.GetGame()
+        {
+            IGame game = null;
+
+            var lineage = DomNode.Lineage;
+            if (lineage?.Count(dn => dn.As<IGame>() != null) > 0)
+            {
+                game = lineage.First(dn => dn.As<IGame>() != null)?.As<IGame>();
+            }
+
+            return game;
+        }
+        #endregion
     }
    
 }

--- a/LevelEditorCore/Interfaces/IGameObject.cs
+++ b/LevelEditorCore/Interfaces/IGameObject.cs
@@ -6,7 +6,9 @@ namespace LevelEditorCore
     /// Interface for game objects</summary>
     public interface IGameObject : ITransformable, INameable, IVisible,ILockable, IListable
     {
-        // todo, add IGame GetGame()
-        // returns the game that owns this gameobject or null.
+        /// <summary>
+        /// Gets the game that owns this game object.</summary>
+        /// <returns>The game that owns this game object, or null if this object isn't owned.</returns>
+        IGame GetGame();
     }
 }


### PR DESCRIPTION
I noticed a commented-out todo in Interfaces/IGameObject.cs and decided to implement it. As the todo described it - the new method should return the IGame that "owns" this object, or null if there is no such game.

The code could be made faster if it's safe to assume that the IGame is the root of the IGameObject's lineage, but I didn't want to make that assumption.